### PR TITLE
Added Single-Sign-On support (optional)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+agendav-2.2.0
+config.inc.php

--- a/README
+++ b/README
@@ -41,7 +41,7 @@ INSTALL
    cd /your/path/to/roundcube/plugins/agendav2
    wget https://github.com/agendav/agendav/releases/download/2.2.0/agendav-2.2.0.tar.gz -O-|tar xzf -
 
-3. Copy agendav.settings.php into /your/path/to/roundcube/plugins/agendav/agendav-2.2.0/web/config/settings.php
+3. Copy agendav.settings.php into /your/path/to/roundcube/plugins/agendav2/agendav-2.2.0/web/config/settings.php
    Change the connection settings for the database and the value for csrf.secret.
 
 
@@ -49,14 +49,27 @@ INSTALL
 CONFIGURATION
 
 1. Copy 'config.inc.php.dist' to 'config.inc.php'.
-   Edit the plugin configuration file 'config.inc.php' and set agendav_path.
+   Edit the plugin configuration file 'config.inc.php' and set agendav_path and
+   agendav_enable_SSO.
 
    // name of agendav root folder
    $config['agendav_path'] = 'agendav-2.2.0';
+   
+   // enable SSO
+   // * it only works when RoundCube and AgenDAV use the same authentication
+   //   backend, because this plugin uses your RoundCube credentials to 
+   //   authenticate to AgenDAV
+   // * if enabled, roundcube calendar options menu will be disabled
+   // * if disabled, you will have to manually enter caldav url, username and
+   //   password in Roundcube Calendar settings
+   $config['agendav_enable_SSO'] = false;
 
 2. Configure AgenDAV according to the documentation:
    http://docs.agendav.org/en/2.2.0/admin/installation/
    No special config is needed to allow AgenDAV work with this plugin.
+   Please note that if you have enabled SSO as explained above, you must set
+   caldav baseurl and any other connection settings (f.e. server certificate
+   verification) into /your/path/to/roundcube/plugins/agendav2/agendav-2.2.0/web/config/settings.php
 
 3. Create and populate the database for AgenDAV.
 

--- a/agendav2.php
+++ b/agendav2.php
@@ -174,13 +174,18 @@ class agendav2 extends rcube_plugin
   function content($attrib)
   {
     $rcmail = rcmail::get_instance();
-
-    $url = $this->rc->config->get('agendav2_url');
-    $username = $this->rc->config->get('agendav2_username');
+    if($rcmail->config->get('agendav_enable_SSO')) {
+      $url = $rcmail->config->get('agendav_caldav.baseurl');
+      $username = $rcmail->get_user_name();
+      $passwd = $rcmail->get_user_password();
+    } else {
+      $url = $this->rc->config->get('agendav2_url');
+      $username = $this->rc->config->get('agendav2_username');
+      $passwd = $this->decrypt($this->rc->config->get('agendav2_passwd'));
+    }
     if (substr($url, -10) === "caldav.php") {
       $url = $url.'/'.$username; // DAViCal url
     }
-    $passwd = $this->decrypt($this->rc->config->get('agendav2_passwd'));
 
     $agendavSessID = $this->createAgendavSession($url, $username, $passwd);
     setcookie('agendav_sess', $agendavSessID, 0);
@@ -208,6 +213,10 @@ class agendav2 extends rcube_plugin
    */
   function agendav2_preferences_sections_list($p)
   {
+    $rcmail = rcmail::get_instance();
+    if($rcmail->config->get('agendav_enable_SSO')) {
+      return false;
+    }
     $this->add_texts('localization/');
     $p['list']['agendav2'] = array(
         'id' => 'agendav2',
@@ -227,6 +236,10 @@ class agendav2 extends rcube_plugin
    */
   function agendav2_preferences_list($p)
   {
+    $rcmail = rcmail::get_instance();
+    if($rcmail->config->get('agendav_enable_SSO')) {
+      return false;
+    }
     $this->add_texts('localization/');
     if($p['section'] != 'agendav2')
       return $p;

--- a/config.inc.php.dist
+++ b/config.inc.php.dist
@@ -7,6 +7,14 @@ $config['agendav_language_map'] = array('*' => 'en_US');
 // name of agendav root folder
 $config['agendav_path'] = 'agendav-2.2.0';
 
+// enable SSO
+// * it only works when RoundCube and AgenDAV use the same authentication
+//   backend, because this plugin uses your RoundCube credentials to 
+//   authenticate to AgenDAV
+// * if enabled, roundcube calendar options menu will be disabled
+// * if disabled, you will have to manually enter caldav url, username and
+//   password in Roundcube Calendar settings
+$config['agendav_enable_SSO'] = false;
 
 // Nothing should be changed after this line
 define('BASEPATH','/');
@@ -19,4 +27,5 @@ $config['agendav_dbname'] = $app['db.options']['dbname'];
 $config['agendav_dbuser'] = $app['db.options']['user'];
 $config['agendav_dbpass'] = $app['db.options']['password'];
 $config['agendav_dbprefix'] = $app['db.options']['dbprefix'];
+$config['agendav_caldav.baseurl'] = $app['caldav.baseurl'];
 ?>

--- a/localization/de_DE.inc
+++ b/localization/de_DE.inc
@@ -3,5 +3,6 @@ $labels['agendav2'] = 'Kalender';
 $labels['calendar'] = 'Kalender';
 $labels['dav_settings'] = 'Kalendereinstellungen';
 $labels['caldav_url'] = 'CalDAV-URL';
+$labels['verifycert'] = 'Zertifikat verifizieren';
 $labels['err_propfind'] = 'Fehler bei der Prüfung des Kalenders. Meldung vom DAV-Server: \'%s\'';
 ?>

--- a/localization/en_US.inc
+++ b/localization/en_US.inc
@@ -3,5 +3,6 @@ $labels['agendav2'] = 'Calendar';
 $labels['calendar'] = 'Calendar';
 $labels['dav_settings'] = 'Calendar settings';
 $labels['caldav_url'] = 'CalDAV-URL';
+$labels['verifycert'] = 'Verify Certificate';
 $labels['err_propfind'] = 'Error checking calendar. Message from remote server: \'%s\'';
 ?>

--- a/localization/it_IT.inc
+++ b/localization/it_IT.inc
@@ -1,0 +1,8 @@
+<?php
+$labels['agendav2'] = 'Calendario';
+$labels['calendar'] = 'Calendario';
+$labels['dav_settings'] = 'Impostazioni calendario';
+$labels['caldav_url'] = 'CalDAV-URL';
+$labels['verifycert'] = 'Verifica Certificato';
+$labels['err_propfind'] = 'Errore nell\'accesso al calendario. Messaggio del server remoto: \'%s\'';
+?>


### PR DESCRIPTION
Add the option to use the same credentials used for roundcube (SSO) when the same authentication backend is used (see issue #6).
@lucabert : This pull request has been developed from my previous pull request/branch dev_davical, so it includes also the solutions to issues #3 and #4: if you wish to accept all my changes, just accept this pull request and not the previous one.