### PR TITLE
fix for elastic skin in roundcube 1.4

### DIFF
--- a/skins/elastic/templates/agendav2.html
+++ b/skins/elastic/templates/agendav2.html
@@ -3,7 +3,7 @@
 
 <h1 class="voice"><roundcube:label name="agendav2.agendav2" /></h1>
 
-<div id="content" class="content selected" role="main">
+<div id="layout-content" role="main">
 	<div class="header">
 		<a class="button icon menu-button" href="#menu"><span class="inner"><roundcube:label name="menu" /></span></a>
 		<span class="header-title agendav2title"><roundcube:label name="agendav2.agendav2" /></span>


### PR DESCRIPTION
This fix is needed in roundcube 1.4, otherwise the calendar iframe is displayed in the list div on the left side and it is too narrow and not scrollable. Partially solves issue #2 (adding support for elastic skin) but only for desktop; for mobile, it would be necessary to patch agendav