### PR TITLE
upgrade agendav to 2.2.1 (fix #9 timezone issue)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-agendav-2.2.0
+agendav-2.2.1
 config.inc.php

--- a/README
+++ b/README
@@ -30,18 +30,18 @@ INSTALL
    // List of active plugins (in plugins/ directory)
    $rcmail_config['plugins'] = array('agendav2');
 
-2. Download AgenDAV from https://github.com/agendav/agendav/releases/download/2.2.0/ and
+2. Download AgenDAV from https://github.com/agendav/agendav/releases/download/2.2.1/ and
    extract it into /plugin/agendav folder:
 
    The resulting folder structure should look like this:
-   /your/path/to/roundcube/plugins/agendav2/agendav-2.2.0
+   /your/path/to/roundcube/plugins/agendav2/agendav-2.2.1
 
    Example (Linux):
 
    cd /your/path/to/roundcube/plugins/agendav2
-   wget https://github.com/agendav/agendav/releases/download/2.2.0/agendav-2.2.0.tar.gz -O-|tar xzf -
+   wget https://github.com/agendav/agendav/releases/download/2.2.1/agendav-2.2.1.tar.gz -O-|tar xzf -
 
-3. Copy agendav.settings.php into /your/path/to/roundcube/plugins/agendav2/agendav-2.2.0/web/config/settings.php
+3. Copy agendav.settings.php into /your/path/to/roundcube/plugins/agendav2/agendav-2.2.1/web/config/settings.php
    Change the connection settings for the database and the value for csrf.secret.
 
 
@@ -53,7 +53,7 @@ CONFIGURATION
    agendav_enable_SSO.
 
    // name of agendav root folder
-   $config['agendav_path'] = 'agendav-2.2.0';
+   $config['agendav_path'] = 'agendav-2.2.1';
    
    // enable SSO
    // * it only works when RoundCube and AgenDAV use the same authentication
@@ -65,11 +65,11 @@ CONFIGURATION
    $config['agendav_enable_SSO'] = false;
 
 2. Configure AgenDAV according to the documentation:
-   http://docs.agendav.org/en/2.2.0/admin/installation/
+   http://docs.agendav.org/en/2.2.1/admin/installation/
    No special config is needed to allow AgenDAV work with this plugin.
    Please note that if you have enabled SSO as explained above, you must set
    caldav baseurl and any other connection settings (f.e. server certificate
-   verification) into /your/path/to/roundcube/plugins/agendav2/agendav-2.2.0/web/config/settings.php
+   verification) into /your/path/to/roundcube/plugins/agendav2/agendav-2.2.1/web/config/settings.php
 
 3. Create and populate the database for AgenDAV.
 
@@ -87,7 +87,7 @@ not a user setting in AgenDAV.
 
 NOTE
 
-Tested with AgenDAV 2.2.0
+Tested with AgenDAV 2.2.1
 Tested with RoundCube 1.4-git
 
 

--- a/config.inc.php.dist
+++ b/config.inc.php.dist
@@ -5,7 +5,7 @@
 $config['agendav_language_map'] = array('*' => 'en_US');
 
 // name of agendav root folder
-$config['agendav_path'] = 'agendav-2.2.0';
+$config['agendav_path'] = 'agendav-2.2.1';
 
 // enable SSO
 // * it only works when RoundCube and AgenDAV use the same authentication


### PR DESCRIPTION
Agendav 2.2.0 is affected by this annoying timezone [bug](https://github.com/agendav/agendav/issues/272),  so that all new entries get shifted of one hour when saved during daylight saving time in EU timezones.

This bug has been fixed in 2.2.1: https://github.com/agendav/agendav/releases/tag/2.2.1

The only difference between 2.2.0 and 2.2.1 is this bug fix (see [here](https://github.com/agendav/agendav/compare/2.2.0...2.2.1), so the upgrade shouldn't affect in any way the plugin functioning